### PR TITLE
Add id-token permission due to provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
       pull-requests: write
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request makes a small update to the permissions in the GitHub Actions workflow. The change grants the workflow permission to write ID tokens, which may be necessary for certain authentication or deployment steps.